### PR TITLE
- refactor : AttachService 레이어 리팩토링

### DIFF
--- a/bootstrap/src/test/java/com/example/attach/AttachUnitTest.java
+++ b/bootstrap/src/test/java/com/example/attach/AttachUnitTest.java
@@ -10,6 +10,7 @@ import com.example.model.attach.AttachModel;
 import com.example.outbound.attach.AttachOutConnector;
 import com.example.s3.utile.FileUtile;
 import com.example.service.attach.AttachService;
+import com.example.service.attach.ThumbnailService;
 import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -42,6 +43,9 @@ public class AttachUnitTest {
 
     @InjectMocks
     private AttachService attachService;
+
+    @InjectMocks
+    private ThumbnailService thumbnailService;
 
     @Mock
     private AttachOutConnector attachOutConnector;
@@ -112,7 +116,7 @@ public class AttachUnitTest {
                 .thenReturn(new URL("https://dummy-url.com/thumb_test-image.jpg"));
 
         // when
-        CompletableFuture<Void> future = attachService.createAndUploadThumbnail(attachModel);
+        CompletableFuture<Void> future = thumbnailService.createAndUploadThumbnail(attachModel);
         future.join();
 
         // then

--- a/common/logging/src/main/java/com/example/logging/MDC/AsyncConfig.java
+++ b/common/logging/src/main/java/com/example/logging/MDC/AsyncConfig.java
@@ -19,8 +19,11 @@ public class AsyncConfig {
         return runnable -> {
             Map<String, String> contextMap = MDC.getCopyOfContextMap();
             return () -> {
+                Map<String, String> backup = MDC.getCopyOfContextMap();
                 if (contextMap != null) MDC.setContextMap(contextMap);
-                runnable.run();
+                if (contextMap != null) MDC.setContextMap(contextMap); else MDC.clear();
+                try { runnable.run(); }
+                finally { if (backup != null) MDC.setContextMap(backup); else MDC.clear();}
             };
         };
     }

--- a/domain/attach/connector/in-bound/src/main/java/com/example/inbound/attach/FailedThumbnailScheduler.java
+++ b/domain/attach/connector/in-bound/src/main/java/com/example/inbound/attach/FailedThumbnailScheduler.java
@@ -3,10 +3,11 @@ package com.example.inbound.attach;
 import com.example.model.attach.AttachModel;
 import com.example.model.attach.FailedThumbnailModel;
 import com.example.service.attach.AttachService;
-import com.example.service.attach.FailedThumbnailService;
+import com.example.service.attach.ThumbnailService;
+import com.example.service.failthumbnail.FailedThumbnailService;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.PageRequest;
+import org.slf4j.MDC;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -18,32 +19,46 @@ import java.util.List;
 public class FailedThumbnailScheduler {
 
     private final FailedThumbnailService failedThumbnailService;
+    private final ThumbnailService thumbnailService;
     private final AttachService attachService;
 
 
     @Scheduled(cron = "0 */5 * * * *")
     public void retryFailedThumbnails() {
-        log.info("🔄 썸네일 재처리 스케줄러 시작");
+        MDC.put("job", "thumbnail-retry");
+        MDC.put("requestId", java.util.UUID.randomUUID().toString());
 
-        List<FailedThumbnailModel> failedList = failedThumbnailService.findRetryTargets(3, 20);
+        try {
+            log.info("🔄 썸네일 재처리 스케줄러 시작");
+            List<FailedThumbnailModel> failedList = failedThumbnailService.findRetryTargets(3, 20);
 
-        if (failedList.isEmpty()) {
-            log.debug("실패 항목 없음. 재처리 스킵");
-            return;
-        }
-
-        for (FailedThumbnailModel target : failedList) {
-            try {
-                AttachModel attach = attachService.findByStoredFileName(target.getStoredFileName());
-                attachService.createAndUploadThumbnail(attach);
-                failedThumbnailService.markResolved(target.getId());
-                log.info("재처리 성공: {}", target.getStoredFileName());
-            } catch (Exception e) {
-                failedThumbnailService.increaseRetryCount(target.getId(), e.getMessage());
-                log.warn("재처리 실패: {}", target.getStoredFileName(), e);
+            if (failedList.isEmpty()) {
+                log.debug("실패 항목 없음. 재처리 스킵");
+                return;
             }
-        }
 
-        log.info("썸네일 재처리 스케줄러 종료 (총 {}건)", failedList.size());
+            for (FailedThumbnailModel target : failedList) {
+                try {
+                    AttachModel attach = attachService.findByStoredFileName(target.getStoredFileName());
+                    thumbnailService.createAndUploadThumbnail(attach);
+                    if (attach.getThumbnailFilePath() != null && !attach.getThumbnailFilePath().isBlank()) {
+                        failedThumbnailService.markResolved(target.getId());
+                        log.info("재처리 성공: {}", target.getStoredFileName());
+                    } else {
+                        failedThumbnailService.increaseRetryCount(target.getId(), "Thumbnail URL missing after retry");
+                        log.warn("재처리 실패(썸네일 URL 미생성): {}", target.getStoredFileName());
+                    }
+                } catch (Exception e) {
+                    failedThumbnailService.increaseRetryCount(target.getId(), e.getMessage());
+                    log.warn("재처리 실패: {}", target.getStoredFileName(), e);
+                }  finally {
+                    MDC.remove("storedFile");
+                }
+            }
+            log.info("썸네일 재처리 스케줄러 종료 (총 {}건)", failedList.size());
+        } finally {
+            MDC.remove("job");
+            MDC.remove("requestId");
+        }
     }
 }

--- a/domain/attach/core/service/src/main/java/com/example/service/attach/AmazonS3Service.java
+++ b/domain/attach/core/service/src/main/java/com/example/service/attach/AmazonS3Service.java
@@ -1,0 +1,54 @@
+package com.example.service.attach;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.net.URL;
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+public class AmazonS3Service {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    // presignedurl 생성
+    public URL generatePresignedUrl(String key, HttpMethod method, long expiresMillis) {
+        Date expiration = new Date(System.currentTimeMillis()+ expiresMillis);
+        GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                new GeneratePresignedUrlRequest(bucketName, key)
+                        .withMethod(method)
+                        .withExpiration(expiration);
+        return amazonS3.generatePresignedUrl(generatePresignedUrlRequest);
+    }
+
+    // S3 파일 경로 수정
+    public void copy(String tempStoredFileName, String finalStoredFileName) {
+        amazonS3.copyObject(bucketName, tempStoredFileName, bucketName, finalStoredFileName);
+    }
+
+    // S3 파일 삭제
+    public void delete(String tempStoredFileName) {
+        amazonS3.deleteObject(bucketName,tempStoredFileName);
+    }
+
+    // S3 파일 경로
+    public String getFileUrl(String finalStoredFileName) {
+        return amazonS3.getUrl(bucketName,finalStoredFileName).toString();
+    }
+
+    // S3 파일 사이즈
+    public Long fileSize(String finalStoredFileName) {
+        ObjectMetadata metadata = amazonS3.getObjectMetadata(bucketName, finalStoredFileName);
+        return metadata.getContentLength();
+    }
+
+}

--- a/domain/attach/core/service/src/main/java/com/example/service/attach/ThumbnailService.java
+++ b/domain/attach/core/service/src/main/java/com/example/service/attach/ThumbnailService.java
@@ -1,0 +1,124 @@
+package com.example.service.attach;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.S3Object;
+import com.example.attach.dto.AttachErrorCode;
+import com.example.attach.exception.AttachCustomExceptionHandler;
+import com.example.model.attach.AttachModel;
+import com.example.model.attach.FailedThumbnailModel;
+import com.example.outbound.attach.AttachOutConnector;
+import com.example.s3.utile.FileUtile;
+import com.example.service.failthumbnail.FailedThumbnailService;
+import io.micrometer.core.annotation.Timed;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.coobird.thumbnailator.Thumbnails;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ThumbnailService {
+
+    private final AmazonS3 amazonS3;
+
+    private final AmazonS3Service amazonS3Service;
+
+    private final AttachOutConnector attachOutConnector;
+
+    private final FailedThumbnailService failedThumbnailService;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    @Value("${server.file.thumbnail-width:200}")
+    private int thumbnailWidth;
+
+    @Value("${server.file.thumbnail-height:200}")
+    private int thumbnailHeight;
+
+
+    @Timed(value = "s3_thumbnail_generation", description = "썸네일 생성 시간", histogram = true)
+    @Async("threadPoolTaskExecutor")
+    public CompletableFuture<Void> createAndUploadThumbnail(AttachModel attachModel) {
+        String fileName = attachModel.getStoredFileName();
+        try {
+            String lower = fileName.toLowerCase();
+            // 1. 이미지 파일 여부 체크
+            if (!FileUtile.isSupportedImageExtension(lower)) {
+                log.info("[섬네일 건너뜀] 이미지 파일 아님: {}", lower);
+                return CompletableFuture.completedFuture(null);
+            }
+
+            log.info("[썸네일 생성 시작] {}", attachModel.getStoredFileName());
+
+            S3Object s3Object = amazonS3.getObject(bucketName, attachModel.getStoredFileName());
+            InputStream inputStream = s3Object.getObjectContent();
+
+            if (!FileUtile.isSupportedImageExtension(lower)) {
+                log.info("[섬네일 건너뜀] MIME 타입으로 확인한 결과 이미지 아님: {}", lower);
+                return CompletableFuture.completedFuture(null);
+            }
+
+            BufferedImage originalImage = ImageIO.read(inputStream);
+
+            if (originalImage == null) {
+                throw new IllegalArgumentException("썸네일 생성 실패: 유효하지 않은 이미지: " + attachModel.getStoredFileName());
+            }
+
+            ByteArrayOutputStream thumbnailOutputStream = new ByteArrayOutputStream();
+
+            // 섬네일 생성.
+            Thumbnails.of(originalImage)
+                    .size(thumbnailWidth, thumbnailHeight)
+                    .outputFormat("jpg")
+                    .toOutputStream(thumbnailOutputStream);
+
+            byte[] thumbnailBytes = thumbnailOutputStream.toByteArray();
+            ByteArrayInputStream thumbnailInputStream = new ByteArrayInputStream(thumbnailBytes);
+
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentLength(thumbnailBytes.length);
+            metadata.setContentType("image/jpeg");
+
+            String thumbnailFileName = "thumb_" + attachModel.getStoredFileName();
+            amazonS3.putObject(bucketName, thumbnailFileName, thumbnailInputStream, metadata);
+
+            String thumbnailUrl = amazonS3Service.getFileUrl(thumbnailFileName);
+
+            attachModel.setThumbnailFilePath(thumbnailUrl);
+            attachOutConnector.updateAttach(attachModel.getId(), attachModel);
+
+            log.info("[썸네일 업로드 완료] {}", thumbnailUrl);
+
+            CompletableFuture<Void> done = new CompletableFuture<>();
+            done.complete(null);
+            return done;
+        } catch (Exception e) {
+            log.error("[썸네일 생성 실패]",e);
+
+            FailedThumbnailModel model = FailedThumbnailModel
+                    .builder()
+                    .storedFileName(attachModel.getStoredFileName())
+                    .retryCount(0)
+                    .reason(e.getMessage())
+                    .resolved(false)
+                    .build();
+            failedThumbnailService.save(model);
+            throw new AttachCustomExceptionHandler(AttachErrorCode.THUMBNAIL_CREATE_FAIL);
+        }
+    }
+
+}

--- a/domain/attach/core/service/src/main/java/com/example/service/failthumbnail/FailedThumbnailService.java
+++ b/domain/attach/core/service/src/main/java/com/example/service/failthumbnail/FailedThumbnailService.java
@@ -1,4 +1,4 @@
-package com.example.service.attach;
+package com.example.service.failthumbnail;
 
 import com.example.model.attach.FailedThumbnailModel;
 import com.example.outbound.attach.FailedThumbnailOutConnector;


### PR DESCRIPTION
- AttachService에서  S3와 섬네일 로직을 분리.
- 섬네일 실패시 실패이력을 catch블록에 저장
- 이미지 생성,섬네일 실패 재처리 MDC 로깅 추가.